### PR TITLE
Fix Linux import and export file dialogs

### DIFF
--- a/src/client/java/maxboxx/blueprints/BlueprintManager.java
+++ b/src/client/java/maxboxx/blueprints/BlueprintManager.java
@@ -182,7 +182,7 @@ public class BlueprintManager {
 
 				if (!selectionData[i].isDirty()) continue;
 
-				selectionData[i].saveData(path);
+				selectionData[i].saveData(path, false);
 
 				if (selectionData[i].graphic != null) {
 					WorldRenderer.removeGraphic(selectionData[i].graphic);
@@ -639,9 +639,9 @@ public class BlueprintManager {
 		}
 	}
 
-	public static void exportTo(Path file) {
+	public static void exportTo(Path file, boolean asSchematic) {
 		if (selection.data != null) {
-			selection.saveData(file);
+			selection.saveData(file, asSchematic);
 			selection.markDirty();
 		}
 	}

--- a/src/client/java/maxboxx/blueprints/BlueprintManager.java
+++ b/src/client/java/maxboxx/blueprints/BlueprintManager.java
@@ -639,11 +639,17 @@ public class BlueprintManager {
 		}
 	}
 
-	public static void exportTo(Path file, boolean asSchematic) {
-		if (selection.data != null) {
-			selection.saveData(file, asSchematic);
-			selection.markDirty();
+	public static boolean exportTo(Path file, boolean asSchematic) {
+		if (selection.data == null) {
+			return false;
 		}
+
+		if (!selection.saveData(file, asSchematic)) {
+			return false;
+		}
+
+		selection.markDirty();
+		return true;
 	}
 
 	private static void updateGraphics() {

--- a/src/client/java/maxboxx/blueprints/data/BlueprintBlockData.java
+++ b/src/client/java/maxboxx/blueprints/data/BlueprintBlockData.java
@@ -172,6 +172,10 @@ public class BlueprintBlockData {
 		return tag;
 	}
 
+	public CompoundTag saveSchematic() {
+		return structure.save(new CompoundTag());
+	}
+
 	public void load(CompoundTag tag, BlockPos position) {
 		structure = new StructureTemplate();
 		blocks    = new HashSet<>();
@@ -186,6 +190,37 @@ public class BlueprintBlockData {
 		}
 
 		structure.load(BuiltInRegistries.BLOCK, blockNbt);
+
+		HashMap<Item, Integer> itemData = new HashMap<>();
+
+		List<StructureTemplate.Palette> palettes = ((StructureTemplateMixins)structure).getStructurePalettes();
+
+		for (StructureTemplate.Palette palette : palettes) {
+			for (StructureTemplate.StructureBlockInfo blockInfo : palette.blocks()) {
+				if (BlockUtil.isPrimaryBlock(blockInfo.state())) {
+					Block block = blockInfo.state().getBlock();
+					blocks.add(block);
+					itemData.put(block.asItem(), itemData.getOrDefault(block.asItem(), 0) + 1);
+				}
+			}
+		}
+
+		for (Map.Entry<Item, Integer> item : itemData.entrySet()) {
+			if (item.getKey() == Items.AIR) {
+				continue;
+			}
+
+			sortedItems.add(new ItemData(new ItemStack(item.getKey(), item.getValue()), true));
+		}
+
+		sortedItems.sort((a, b) -> b.stack.getCount() - a.stack.getCount());
+	}
+
+	public void loadSchematic(CompoundTag tag) {
+		structure = new StructureTemplate();
+		blocks    = new HashSet<>();
+		pos       = BlockPos.ZERO;
+		structure.load(BuiltInRegistries.BLOCK, tag);
 
 		HashMap<Item, Integer> itemData = new HashMap<>();
 

--- a/src/client/java/maxboxx/blueprints/data/BlueprintData.java
+++ b/src/client/java/maxboxx/blueprints/data/BlueprintData.java
@@ -11,7 +11,9 @@ import net.minecraft.nbt.Tag;
 import java.nio.file.Path;
 
 public class BlueprintData {
-	public static final String[] FILE_FILTERS = new String[] {"*.dat"};
+	public static final String[] BLUEPRINT_FILTERS = new String[] {"*.dat"};
+	public static final String[] SCHEMATIC_FILTERS = new String[] {"*.nbt"};
+	public static final String[] IMPORT_FILTERS = new String[] {"*.dat", "*.nbt"};
 
 	public boolean isActive = false;
 	public BlockPos min = BlockPos.ZERO, max = BlockPos.ZERO;
@@ -33,7 +35,7 @@ public class BlueprintData {
 		dirty = true;
 	}
 
-	public void saveData(Path file) {
+	public void saveData(Path file, boolean asSchematic) {
 		try {
 			if (!isActive && data == null) {
 				file.toFile().delete();
@@ -41,18 +43,25 @@ public class BlueprintData {
 				return;
 			}
 
-			CompoundTag data = new CompoundTag();
-			data.putBoolean("active", isActive);
-			data.putBoolean("visible", isVisible);
-			data.putString("name", name);
+			CompoundTag data;
 
-			if (isActive) {
-				data.putIntArray("min", new int[] {min.getX(), min.getY(), min.getZ()});
-				data.putIntArray("max", new int[] {max.getX(), max.getY(), max.getZ()});
+			if (asSchematic) {
+				data = this.data != null ? this.data.saveSchematic() : new CompoundTag();
 			}
+			else {
+				data = new CompoundTag();
+				data.putBoolean("active", isActive);
+				data.putBoolean("visible", isVisible);
+				data.putString("name", name);
 
-			if (this.data != null) {
-				data.put("data", this.data.save());
+				if (isActive) {
+					data.putIntArray("min", new int[] {min.getX(), min.getY(), min.getZ()});
+					data.putIntArray("max", new int[] {max.getX(), max.getY(), max.getZ()});
+				}
+
+				if (this.data != null) {
+					data.put("data", this.data.save());
+				}
 			}
 
 			NbtIo.writeCompressed(data, file);
@@ -71,25 +80,37 @@ public class BlueprintData {
 
 			CompoundTag data = NbtIo.readCompressed(file, NbtAccounter.unlimitedHeap());
 
-			isActive  = data.getBooleanOr("active", false);
-			isVisible = data.getBooleanOr("visible", true);
-			name      = data.getStringOr("name", "");
+			boolean isSchematic = !data.contains("active") || !data.contains("visible") || !data.contains("name");
 
-			data.getIntArray("min").ifPresent(values -> {
-				if (values.length < 3) return;
-				min = new BlockPos(values[0], values[1], values[2]);
-			});
+			if (isSchematic) {
+				isActive = false;
+				isVisible = true;
+				name = "";
 
-			data.getIntArray("max").ifPresent(values -> {
-				if (values.length < 3) return;
-				max = new BlockPos(values[0], values[1], values[2]);
-			});
-
-			Tag tag = data.get("data");
-
-			if (tag instanceof CompoundTag nbt) {
 				this.data = new BlueprintBlockData();
-				this.data.load(nbt, min);
+				this.data.loadSchematic(data);
+			}
+			else {
+				isActive = data.getBooleanOr("active", false);
+				isVisible = data.getBooleanOr("visible", true);
+				name = data.getStringOr("name", "");
+
+				data.getIntArray("min").ifPresent(values -> {
+					if (values.length < 3) return;
+					min = new BlockPos(values[0], values[1], values[2]);
+				});
+
+				data.getIntArray("max").ifPresent(values -> {
+					if (values.length < 3) return;
+					max = new BlockPos(values[0], values[1], values[2]);
+				});
+
+				Tag tag = data.get("data");
+
+				if (tag instanceof CompoundTag nbt) {
+					this.data = new BlueprintBlockData();
+					this.data.load(nbt, min);
+				}
 			}
 		} catch (Exception e) {
 			SimpleBlueprints.LOGGER.info("Failed to load blueprint data", e);

--- a/src/client/java/maxboxx/blueprints/data/BlueprintData.java
+++ b/src/client/java/maxboxx/blueprints/data/BlueprintData.java
@@ -8,6 +8,7 @@ import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.Tag;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class BlueprintData {
@@ -35,12 +36,12 @@ public class BlueprintData {
 		dirty = true;
 	}
 
-	public void saveData(Path file, boolean asSchematic) {
+	public boolean saveData(Path file, boolean asSchematic) {
 		try {
 			if (!isActive && data == null) {
 				file.toFile().delete();
 				dirty = false;
-				return;
+				return true;
 			}
 
 			CompoundTag data;
@@ -65,8 +66,14 @@ public class BlueprintData {
 			}
 
 			NbtIo.writeCompressed(data, file);
+			if (!Files.isRegularFile(file)) {
+				SimpleBlueprints.LOGGER.error("Blueprint export completed without creating a regular file");
+				return false;
+			}
+			return true;
 		} catch (Exception e) {
-			SimpleBlueprints.LOGGER.info("Failed to save blueprint data", e);
+			SimpleBlueprints.LOGGER.error("Failed to save blueprint data", e);
+			return false;
 		}
 	}
 

--- a/src/client/java/maxboxx/blueprints/graphics/ui/screens/ImportExportScreen.java
+++ b/src/client/java/maxboxx/blueprints/graphics/ui/screens/ImportExportScreen.java
@@ -7,11 +7,13 @@ import maxboxx.blueprints.utils.FileUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
+import java.util.Locale;
 
 public class ImportExportScreen extends Screen {
 	private static final int COL_WIDTH = 120;
@@ -21,6 +23,7 @@ public class ImportExportScreen extends Screen {
 
 	private Button importButton;
 	private Button exportButton;
+	private Button exportSchematicButton;
 	private Button cancelButton;
 
 	public ImportExportScreen() {
@@ -30,8 +33,8 @@ public class ImportExportScreen extends Screen {
 	@Override
 	protected void init() {
 		importButton = Button.builder(SimpleBlueprints.text("import.import"), b -> {
-			FileUtil.openFileDialogAsync(SimpleBlueprints.text("import.select_import").getString(), BlueprintData.FILE_FILTERS, path -> {
-				if (!path.endsWith(".dat")) {
+			FileUtil.openFileDialogAsync(SimpleBlueprints.text("import.select_import").getString(), BlueprintData.IMPORT_FILTERS, path -> {
+				if (!hasExtension(path, ".dat") && !hasExtension(path, ".nbt")) {
 					return;
 				}
 
@@ -41,15 +44,30 @@ public class ImportExportScreen extends Screen {
 		}).width(COL_WIDTH).build();
 
 		exportButton = Button.builder(SimpleBlueprints.text("import.export"), b -> {
-			FileUtil.saveFileDialogAsync(SimpleBlueprints.text("import.select_export").getString(), BlueprintData.FILE_FILTERS, path -> {
-				if (!path.endsWith(".dat")) {
+			FileUtil.saveFileDialogAsync(SimpleBlueprints.text("import.select_export").getString(), BlueprintData.BLUEPRINT_FILTERS, path -> {
+				path = appendExtension(path, ".dat");
+				if (path == null) {
 					return;
 				}
 
-				BlueprintManager.exportTo(Path.of(path));
+				BlueprintManager.exportTo(Path.of(path), false);
 				Minecraft.getInstance().setScreen(null);
 			});
 		}).width(COL_WIDTH).build();
+		exportButton.setTooltip(Tooltip.create(SimpleBlueprints.text("import.export_tooltip")));
+
+		exportSchematicButton = Button.builder(SimpleBlueprints.text("import.export_schematic"), b -> {
+			FileUtil.saveFileDialogAsync(SimpleBlueprints.text("import.select_export").getString(), BlueprintData.SCHEMATIC_FILTERS, path -> {
+				path = appendExtension(path, ".nbt");
+				if (path == null) {
+					return;
+				}
+
+				BlueprintManager.exportTo(Path.of(path), true);
+				Minecraft.getInstance().setScreen(null);
+			});
+		}).width(COL_WIDTH).build();
+		exportSchematicButton.setTooltip(Tooltip.create(SimpleBlueprints.text("import.export_schematic_tooltip")));
 
 		cancelButton = Button.builder(SimpleBlueprints.text("import.cancel"), b -> {
 			Minecraft.getInstance().setScreen(null);
@@ -57,6 +75,7 @@ public class ImportExportScreen extends Screen {
 
 		addRenderableWidget(importButton);
 		addRenderableWidget(exportButton);
+		addRenderableWidget(exportSchematicButton);
 		addRenderableWidget(cancelButton);
 	}
 
@@ -66,10 +85,12 @@ public class ImportExportScreen extends Screen {
 		int originY = context.guiHeight() / 2 + 30;
 
 		importButton.setPosition(originX - COL_WIDTH_GAP, originY);
-		exportButton.setPosition(originX + HALF_GAP, originY);
+		exportButton.setPosition(originX + HALF_GAP, originY - 25);
+		exportSchematicButton.setPosition(originX + HALF_GAP, originY);
 		cancelButton.setPosition(originX - COL_WIDTH / 2, originY + 40);
 
 		exportButton.visible = BlueprintManager.hasData();
+		exportSchematicButton.visible = BlueprintManager.hasData();
 
 		context.fill(originX - COL_WIDTH_GAP - 5, originY - 105, originX - HALF_GAP + 5, originY + 25, 0x44000000);
 		context.fill(originX + HALF_GAP - 5, originY - 105, originX + HALF_GAP + COL_WIDTH + 5, originY + 25, 0x44000000);
@@ -85,7 +106,18 @@ public class ImportExportScreen extends Screen {
 			context.drawWordWrap(this.font, SimpleBlueprints.text("import.import_warning", selectedSlot), originX - COL_WIDTH_GAP, originY - 45, COL_WIDTH, 0xffff8888);
 		}
 		else {
-			context.drawWordWrap(this.font, SimpleBlueprints.text("import.export_warning", selectedSlot), originX + HALF_GAP, originY - 45, COL_WIDTH, 0xffff8888);
+			context.drawWordWrap(this.font, SimpleBlueprints.text("import.export_warning", selectedSlot), originX + HALF_GAP, originY - 65, COL_WIDTH, 0xffff8888);
 		}
+	}
+
+	private static boolean hasExtension(String path, String extension) {
+		return path.toLowerCase(Locale.ROOT).endsWith(extension);
+	}
+
+	private static String appendExtension(String path, String extension) {
+		if (path.isEmpty()) {
+			return null;
+		}
+		return hasExtension(path, extension) ? path : path + extension;
 	}
 }

--- a/src/client/java/maxboxx/blueprints/graphics/ui/screens/ImportExportScreen.java
+++ b/src/client/java/maxboxx/blueprints/graphics/ui/screens/ImportExportScreen.java
@@ -50,8 +50,9 @@ public class ImportExportScreen extends Screen {
 					return;
 				}
 
-				BlueprintManager.exportTo(Path.of(path), false);
-				Minecraft.getInstance().setScreen(null);
+				if (BlueprintManager.exportTo(Path.of(path), false)) {
+					Minecraft.getInstance().setScreen(null);
+				}
 			});
 		}).width(COL_WIDTH).build();
 		exportButton.setTooltip(Tooltip.create(SimpleBlueprints.text("import.export_tooltip")));
@@ -63,8 +64,9 @@ public class ImportExportScreen extends Screen {
 					return;
 				}
 
-				BlueprintManager.exportTo(Path.of(path), true);
-				Minecraft.getInstance().setScreen(null);
+				if (BlueprintManager.exportTo(Path.of(path), true)) {
+					Minecraft.getInstance().setScreen(null);
+				}
 			});
 		}).width(COL_WIDTH).build();
 		exportSchematicButton.setTooltip(Tooltip.create(SimpleBlueprints.text("import.export_schematic_tooltip")));

--- a/src/client/java/maxboxx/blueprints/utils/FileUtil.java
+++ b/src/client/java/maxboxx/blueprints/utils/FileUtil.java
@@ -1,14 +1,26 @@
 package maxboxx.blueprints.utils;
 
+import maxboxx.blueprints.SimpleBlueprints;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.Minecraft;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.util.tinyfd.TinyFileDialogs;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -22,47 +34,253 @@ public class FileUtil {
 	private static final AtomicBoolean DIALOG_STATE = new AtomicBoolean(false);
 
 	public static void openFileDialogAsync(String title, String[] filters, Consumer<String> callback) {
+		showFileDialogAsync(DialogType.OPEN, title, filters, callback);
+	}
+
+	public static void saveFileDialogAsync(String title, String[] filters, Consumer<String> callback) {
+		showFileDialogAsync(DialogType.SAVE, title, filters, callback);
+	}
+
+	private static void showFileDialogAsync(DialogType type, String title, String[] filters, Consumer<String> callback) {
 		if (!DIALOG_STATE.compareAndSet(false, true)) {
 			return;
 		}
 
-		DIALOG_EXECUTOR.submit(() -> {
-			try (MemoryStack stack = MemoryStack.stackPush()) {
-				PointerBuffer buffer = toPointerBuffer(stack, filters);
+		try {
+			DIALOG_EXECUTOR.submit(() -> {
+				try {
+					Path startingDirectory = getStartingDirectory();
+					DialogResult result = isLinux()
+						? runLinuxDialog(type, title, startingDirectory, filters)
+						: runTinyFileDialog(type, title, startingDirectory, filters);
 
-				String path = TinyFileDialogs.tinyfd_openFileDialog(title, "", buffer, null, false);
+					if (result.status() == DialogStatus.SELECTED) {
+						dispatchSuccess(result.path(), callback);
+					}
+				}
+				catch (Throwable throwable) {
+					SimpleBlueprints.LOGGER.error("Unexpected file dialog failure", throwable);
+				}
+				finally {
+					DIALOG_STATE.set(false);
+				}
+			});
+		}
+		catch (RejectedExecutionException exception) {
+			DIALOG_STATE.set(false);
+			SimpleBlueprints.LOGGER.error("File dialog executor rejected the request", exception);
+		}
+	}
 
-				Minecraft.getInstance().execute(() -> {
-					if (path == null) return;
-					callback.accept(path);
-				});
+	private static DialogResult runLinuxDialog(DialogType type, String title, Path startingDirectory, String[] filters) {
+		DialogResult result = runKDialog(type, title, startingDirectory, filters);
+		if (result.status() != DialogStatus.FAILED || Thread.currentThread().isInterrupted()) {
+			return result;
+		}
+
+		SimpleBlueprints.LOGGER.info("Falling back to zenity");
+		result = runZenity(type, title, startingDirectory, filters);
+		if (result.status() != DialogStatus.FAILED || Thread.currentThread().isInterrupted()) {
+			return result;
+		}
+
+		SimpleBlueprints.LOGGER.info("Falling back to TinyFileDialogs");
+		result = runTinyFileDialog(type, title, startingDirectory, filters);
+		if (result.status() == DialogStatus.FAILED) {
+			SimpleBlueprints.LOGGER.error("All file-dialog backends failed");
+		}
+
+		return result;
+	}
+
+	private static DialogResult runKDialog(DialogType type, String title, Path startingDirectory, String[] filters) {
+		List<String> command = new ArrayList<>();
+		command.add("kdialog");
+		command.add("--title");
+		command.add(title);
+		command.add(type == DialogType.OPEN ? "--getopenfilename" : "--getsavefilename");
+		command.add(startingDirectory.toString());
+		command.add(toKDialogFilter(filters));
+		return runExternalDialog("kdialog", command);
+	}
+
+	private static DialogResult runZenity(DialogType type, String title, Path startingDirectory, String[] filters) {
+		List<String> command = new ArrayList<>();
+		command.add("zenity");
+		command.add("--file-selection");
+		if (type == DialogType.SAVE) {
+			command.add("--save");
+			command.add("--confirm-overwrite");
+		}
+		command.add("--title");
+		command.add(title);
+		command.add("--filename");
+		command.add(startingDirectory + File.separator);
+		command.add("--file-filter");
+		command.add(toZenityFilter(filters));
+		return runExternalDialog("zenity", command);
+	}
+
+	private static DialogResult runExternalDialog(String backend, List<String> command) {
+		SimpleBlueprints.LOGGER.info("Trying file dialog backend: {}", backend);
+
+		try {
+			ProcessResult result = runDialogProcess(command);
+			if (result.exitCode() == 0) {
+				return result.stdout().isEmpty() ? DialogResult.cancelled() : DialogResult.selected(result.stdout());
 			}
-			finally {
-				DIALOG_STATE.set(false);
+			if (result.exitCode() == 1) {
+				return DialogResult.cancelled();
+			}
+
+			SimpleBlueprints.LOGGER.warn("{} failed with exit code {}", backend, result.exitCode());
+			if (!result.stderr().isEmpty()) {
+				SimpleBlueprints.LOGGER.warn("{} stderr: {}", backend, result.stderr());
+			}
+			return DialogResult.failed();
+		}
+		catch (InterruptedException exception) {
+			Thread.currentThread().interrupt();
+			SimpleBlueprints.LOGGER.warn("{} file dialog was interrupted", backend);
+			return DialogResult.failed();
+		}
+		catch (IOException exception) {
+			SimpleBlueprints.LOGGER.info("{} unavailable or could not start: {}", backend, exception.getMessage());
+			return DialogResult.failed();
+		}
+	}
+
+	private static ProcessResult runDialogProcess(List<String> command) throws IOException, InterruptedException {
+		Path stdoutFile = Files.createTempFile("simple-blueprints-dialog-", ".out");
+		Path stderrFile = null;
+		Process process = null;
+
+		try {
+			stderrFile = Files.createTempFile("simple-blueprints-dialog-", ".err");
+			process = new ProcessBuilder(command)
+				.redirectOutput(stdoutFile.toFile())
+				.redirectError(stderrFile.toFile())
+				.start();
+
+			int exitCode;
+			try {
+				exitCode = process.waitFor();
+			}
+			catch (InterruptedException exception) {
+				destroyProcess(process);
+				throw exception;
+			}
+
+			String stdout = stripTrailingLineTerminators(Files.readString(stdoutFile, StandardCharsets.UTF_8));
+			String stderr = stripTrailingLineTerminators(Files.readString(stderrFile, StandardCharsets.UTF_8));
+			return new ProcessResult(exitCode, stdout, stderr);
+		}
+		finally {
+			if (process != null && process.isAlive()) {
+				destroyProcess(process);
+			}
+			deleteTempFile(stdoutFile);
+			if (stderrFile != null) {
+				deleteTempFile(stderrFile);
+			}
+		}
+	}
+
+	private static void destroyProcess(Process process) {
+		process.destroy();
+		try {
+			if (!process.waitFor(1, TimeUnit.SECONDS)) {
+				process.destroyForcibly();
+			}
+		}
+		catch (InterruptedException exception) {
+			process.destroyForcibly();
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	private static void deleteTempFile(Path file) {
+		try {
+			Files.deleteIfExists(file);
+		}
+		catch (IOException exception) {
+			SimpleBlueprints.LOGGER.debug("Failed to delete file dialog temporary output", exception);
+		}
+	}
+
+	private static DialogResult runTinyFileDialog(DialogType type, String title, Path startingDirectory, String[] filters) {
+		SimpleBlueprints.LOGGER.info("Trying file dialog backend: TinyFileDialogs");
+
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			PointerBuffer buffer = toPointerBuffer(stack, filters);
+			String initialPath = startingDirectory + File.separator;
+			String path = type == DialogType.OPEN
+				? TinyFileDialogs.tinyfd_openFileDialog(title, initialPath, buffer, null, false)
+				: TinyFileDialogs.tinyfd_saveFileDialog(title, initialPath, buffer, null);
+
+			return path == null || path.isEmpty() ? DialogResult.cancelled() : DialogResult.selected(path);
+		}
+		catch (Throwable throwable) {
+			SimpleBlueprints.LOGGER.error("TinyFileDialogs failed", throwable);
+			return DialogResult.failed();
+		}
+	}
+
+	private static void dispatchSuccess(String path, Consumer<String> callback) {
+		Minecraft.getInstance().execute(() -> {
+			try {
+				callback.accept(path);
+			}
+			catch (Throwable throwable) {
+				SimpleBlueprints.LOGGER.error("File dialog callback failed", throwable);
 			}
 		});
 	}
 
-	public static void saveFileDialogAsync(String title, String[] filters, Consumer<String> callback) {
-		if (!DIALOG_STATE.compareAndSet(false, true)) {
-			return;
+	private static Path getStartingDirectory() {
+		Path gameDirectory = FabricLoader.getInstance().getGameDir();
+		if (Files.isDirectory(gameDirectory)) {
+			return gameDirectory;
 		}
 
-		DIALOG_EXECUTOR.submit(() -> {
-			try (MemoryStack stack = MemoryStack.stackPush()) {
-				PointerBuffer buffer = toPointerBuffer(stack, filters);
-
-				String path = TinyFileDialogs.tinyfd_saveFileDialog(title, "", buffer, null);
-
-				Minecraft.getInstance().execute(() -> {
-					if (path == null) return;
-					callback.accept(path);
-				});
+		String userHome = System.getProperty("user.home");
+		if (userHome != null && !userHome.isEmpty()) {
+			try {
+				Path homeDirectory = Path.of(userHome);
+				if (Files.isDirectory(homeDirectory)) {
+					return homeDirectory;
+				}
 			}
-			finally {
-				DIALOG_STATE.set(false);
+			catch (RuntimeException ignored) {
+				// Fall back to the process working directory.
 			}
-		});
+		}
+
+		return Path.of(".").toAbsolutePath().normalize();
+	}
+
+	private static boolean isLinux() {
+		return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux");
+	}
+
+	private static String toKDialogFilter(String[] filters) {
+		return "Supported files (" + String.join(" ", filters) + ")";
+	}
+
+	private static String toZenityFilter(String[] filters) {
+		return "Supported files | " + String.join(" ", filters);
+	}
+
+	private static String stripTrailingLineTerminators(String value) {
+		int end = value.length();
+		while (end > 0) {
+			char character = value.charAt(end - 1);
+			if (character != '\n' && character != '\r') {
+				break;
+			}
+			end--;
+		}
+		return value.substring(0, end);
 	}
 
 	private static PointerBuffer toPointerBuffer(MemoryStack stack, String[] strings) {
@@ -83,5 +301,33 @@ public class FileUtil {
 
 		buffer.flip();
 		return buffer;
+	}
+
+	private enum DialogType {
+		OPEN,
+		SAVE
+	}
+
+	private enum DialogStatus {
+		SELECTED,
+		CANCELLED,
+		FAILED
+	}
+
+	private record DialogResult(DialogStatus status, String path) {
+		private static DialogResult selected(String path) {
+			return new DialogResult(DialogStatus.SELECTED, path);
+		}
+
+		private static DialogResult cancelled() {
+			return new DialogResult(DialogStatus.CANCELLED, null);
+		}
+
+		private static DialogResult failed() {
+			return new DialogResult(DialogStatus.FAILED, null);
+		}
+	}
+
+	private record ProcessResult(int exitCode, String stdout, String stderr) {
 	}
 }

--- a/src/client/resources/assets/simple_blueprints/lang/en_us.json
+++ b/src/client/resources/assets/simple_blueprints/lang/en_us.json
@@ -66,12 +66,15 @@
   "simple_blueprints.bounds.size": "Size: %1$s, %2$s, %3$s",
 
   "simple_blueprints.import.import": "Import",
-  "simple_blueprints.import.export": "Export",
+  "simple_blueprints.import.export": "Export Blueprint",
+  "simple_blueprints.import.export_schematic": "Export Schematic",
   "simple_blueprints.import.cancel": "Cancel",
   "simple_blueprints.import.select_import": "Select Blueprint",
   "simple_blueprints.import.select_export": "Select Export Location",
-  "simple_blueprints.import.import_desc": "Imports a blueprint from a file. This will replace the blueprint data for slot %1$s.",
+  "simple_blueprints.import.import_desc": "Imports a blueprint or schematic from a file. This will replace the blueprint data for slot %1$s.",
   "simple_blueprints.import.export_desc": "Exports the blueprint data in slot %1$s to a file.",
+  "simple_blueprints.import.export_tooltip": "Exports the blueprint data including world placement and blueprint name. Only compatible with this mod.",
+  "simple_blueprints.import.export_schematic_tooltip": "Exports the blueprint schematic as a vanilla nbt file. Compatible with structure blocks and other mods.",
   "simple_blueprints.import.import_warning": "Slot %1$s currently has data. This will be lost if you import.",
   "simple_blueprints.import.export_warning": "Slot %1$s can not be exported since it has no data.",
 


### PR DESCRIPTION
## Summary

Fixes Import, Export Blueprint, and Export Schematic on Linux. It prefers kdialog on KDE systems and falls back to zenity or TinyFileDialogs on other Linux desktops.

## Changes

- Uses kdialog on Linux when available
- Falls back to zenity, then TinyFileDialogs
- Distinguishes cancellation from backend failure
- Keeps dialog execution off the render thread
- Shows .dat and .nbt filters
- Adds case-insensitive extension handling
- Appends .dat or .nbt exactly once during export
- Keeps the screen open when exporting fails
- Logs backend and file-writing failures
- Preserves TinyFileDialogs on Windows and macOS

## Supported formats

- SimpleBlueprints blueprint: `.dat`
- Vanilla structure schematic: `.nbt`

Sponge `.schem` is not supported.

## Testing

Tested on Fedora 44 KDE with Prism Launcher and Java 21:

- Import opens through kdialog
- `.dat` blueprint import and export work
- `.nbt` schematic import and export work
- Missing export extensions are appended correctly
- Cancelling leaves the Import/Export screen open
- Minecraft remains responsive while the dialog is open